### PR TITLE
fix: account for NWC var not being defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 WINDOWS := $(shell which wine ; echo $$?)
 UNAME_S := $(shell uname -s)
 
-tetris_obj := main.o tetris-ram.o tetris.o
+tetris_obj := tetris-ram.o tetris.o
 cc65Path := cc65
 
 # Hack for OSX
@@ -15,7 +15,7 @@ CA65 := $(cc65Path)/bin/ca65
 LD65 := $(cc65Path)/bin/ld65
 nesChrEncode := python3 tools/nes-util/nes_chr_encode.py
 
-tetris.nes: tetris.o main.o tetris-ram.o
+tetris.nes: tetris.o tetris-ram.o
 
 tetris:= tetris.nes
 

--- a/main.asm
+++ b/main.asm
@@ -1,5 +1,7 @@
         .setcpu "6502"
 
+.include "constants.asm"
+
 tmp1            := $0000
 tmp2            := $0001
 tmp3            := $0002
@@ -234,8 +236,6 @@ highScoreScoresA:= $0730
 highScoreScoresB:= $073C
 highScoreLevels := $0748
 initMagic       := $0750                        ; Initialized to a hard-coded number. When resetting, if not correct number then it knows this is a cold boot
-
-.include "constants.asm"
 
 .feature force_range ; allows -1 vs <-1 (used in orientationTable)
 

--- a/tetris.asm
+++ b/tetris.asm
@@ -18,6 +18,8 @@ INES_SRAM   = 0 ; 1 = battery backed SRAM at $6000-7FFF
 .byte (INES_MAPPER & %11110000)
 .byte $0, $0, $0, $0, $0, $0, $0, $0 ; padding
 
+; PRG segments
+.include "main.asm"
 
 .segment "CHR"
 .incbin "gfx/title_menu_tileset.chr"


### PR DESCRIPTION
Addresses #16 

Did not properly test NWC not being defined.  This moves main.asm to be part of tetris.asm so that NWC being defined in constants.asm applies to the tileset test.  This also moves the include statement for constants.asm  to the top of main.asm so it exists above the check for the vars.   Apologies for the miss.

